### PR TITLE
Update SCCM secrets extraction and policies pivoting

### DIFF
--- a/docs/src/ad/movement/sccm-mecm/index.md
+++ b/docs/src/ad/movement/sccm-mecm/index.md
@@ -210,3 +210,5 @@ After the SCCM infrastructure compromise, this page will describe how to pivot t
 [https://posts.specterops.io/sccm-hierarchy-takeover-41929c61e087](https://posts.specterops.io/sccm-hierarchy-takeover-41929c61e087)
 
 [https://posts.specterops.io/sccm-hierarchy-takeover-with-high-availability-7dcbd3696b43](https://posts.specterops.io/sccm-hierarchy-takeover-with-high-availability-7dcbd3696b43)
+
+[https://www.synacktiv.com/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial](https://www.synacktiv.com/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial)

--- a/docs/src/ad/movement/sccm-mecm/lateral-movement.md
+++ b/docs/src/ad/movement/sccm-mecm/lateral-movement.md
@@ -37,16 +37,31 @@ SharpSCCM.exe get class-instances SMS_SCI_Reserved
 
 Admin user enumeration in SCCM{.caption}
 
-
 ![](<./assets/SCCM_Lateral_Movement_Special_Account_Enum.png>)
 
 Special Account Enumeration in SCCM{.caption}
 
-
-
-
 :::
 
+### Secret policies pivoting
+
+Secret policies are linked to the device collections a device is member of. When a new device is compromised, it can be used to request the policies it can access and potentially find new credentials.
+
+Find more details about this in [this blog](https://www.synacktiv.com/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial) post.
+
+To request SCCM policies with an already enrolled device, its GUID (to identify it) and its private key (to sign the requests) are needed.
+
+* The GUID can be found in different log files, like `C:/Windows/CCM/Logs/ClientIDManagerStartup.log` on the machine
+* The private key can be extracted from the LSASS memory by previously patching the CNG with Mimikatz, or by dumping it from the SYSTEM DPAPI
+
+Then, the requests can be performed like this. The folder `CLIENT_DEVICE` must contain two files:
+
+* `guid.txt` where the GUID is written
+* `key.pem` containing the private key
+
+```bash
+python3 SCCMSecrets.py policies -mp http://$MP_FQDN --use-existing-device CLIENT_DEVICE/
+```
 
 ### Applications and scripts deployment
 
@@ -223,3 +238,5 @@ There is nothing to do. Just promote a user to any SCCM administrative role on a
 [https://enigma0x3.net/2016/02/](https://enigma0x3.net/2016/02/)
 
 [https://posts.specterops.io/sccm-hierarchy-takeover-41929c61e087](https://posts.specterops.io/sccm-hierarchy-takeover-41929c61e087)
+
+[https://www.synacktiv.com/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial](https://www.synacktiv.com/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial)


### PR DESCRIPTION
Hi ! Just a PR to update the SCCM secrets extraction techniques, essentially with SCCMSecrets. Another attack regarding the lateral movement with policies pivoting has been added.

The credentials harvesting section has been restructured to separate local extraction, and extraction through policies.

This is my first PR with the new Markdown syntax, so be careful with the rendering 😄 