### PR TITLE
Fix `--kdcHost` option typo from `netexec` tool

### DIFF
--- a/docs/src/ad/movement/kerberos/asreproast.md
+++ b/docs/src/ad/movement/kerberos/asreproast.md
@@ -42,7 +42,7 @@ GetNPUsers.py -request -format hashcat -outputfile ASREProastables.txt -hashes '
 This can also be achieved with [NetExec](https://github.com/Pennyw0rth/NetExec) (Python).
 
 ```bash
-netexec ldap $TARGETS -u $USER -p $PASSWORD --asreproast ASREProastables.txt --KdcHost $KeyDistributionCenter
+netexec ldap $TARGETS -u $USER -p $PASSWORD --asreproast ASREProastables.txt --kdcHost $KeyDistributionCenter
 ```
 
 The [kerberoast](https://github.com/skelsec/kerberoast) pure-python toolkit is a good alternative to the tools mentioned above.


### PR DESCRIPTION
Just a little typo, as `--kdcHost` is `camelCase` instead of `PascalCase` (https://www.netexec.wiki/ldap-protocol/asreproast#with-authentication):
![image](https://github.com/user-attachments/assets/637f9bdc-c0e4-42f1-b188-ee2a74806ded)

(`docs/src/ad/movement/kerberos/kerberoast.md` is good, nothing to change :+1: )
