### PR TITLE
Normalize author usernames (case)

### DIFF
--- a/docs/.vitepress/authors.data.ts
+++ b/docs/.vitepress/authors.data.ts
@@ -23,7 +23,9 @@ export default createContentLoader('../src/**/*.md', {
     })
 
     //Sort
-    const uniqueAuthors = Array.from(authorSet).sort((a, b) => a.localeCompare(b))
+    const uniqueAuthors = Array.from(
+      new Set(Array.from(authorSet).map(author => author.toLowerCase()))
+    ).sort((a, b) => a.localeCompare(b));
 
     //DEBUG
     //console.log('Auteurs trouvés :', uniqueAuthors)


### PR DESCRIPTION
Normalize author usernames to lowercase to prevent duplicates caused by case differences (e.g., `username` and `Username`)