### PR TITLE
Update vitepress-md-var to 0.2.3 and add variable reset button

### DIFF
--- a/docs/src/contributing/variables.md
+++ b/docs/src/contributing/variables.md
@@ -46,4 +46,42 @@ $INTERFACE    # Network interface (e.g., "eth0" or "tun0")
 
 ## Resetting variables
 
-All saved variables automatically expire after 24 hours. If you need to reset them before that, you can clear your browser's local storage for this website.
+All saved variables automatically expire after 24 hours. If you need to reset them before that, click the button below:
+
+<style>
+    .reset-button {
+        background-color: #ff4d4d;
+        color: white;
+        padding: 0.5rem 1rem;
+        font-size: 0.9rem;
+        font-weight: 500;
+        border-radius: 4px;
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+    }
+
+    .reset-button:hover {
+        background-color: #cc0000;
+    }
+
+    .reset-button:active {
+        background-color: #990000;
+    }
+</style>
+
+<button class="reset-button" @click="resetVariables()">Reset variables</button>
+
+<script setup>
+function resetVariables(){
+  const dataToStore = {
+    timestamp: Date.now(),
+    values: {}
+  }
+  localStorage.setItem("thr_commands_variables", JSON.stringify(dataToStore))
+
+  setTimeout(() => {
+    window.location.reload()
+  }, 500)
+}
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "patch-package": "^8.0.0",
         "postinstall-postinstall": "^2.1.0",
-        "vitepress-md-var": "^0.2.2",
+        "vitepress-md-var": "^0.2.3",
         "vitepress-plugin-tabs": "^0.5.0"
       }
     },
@@ -3182,9 +3182,9 @@
       }
     },
     "node_modules/vitepress-md-var": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/vitepress-md-var/-/vitepress-md-var-0.2.2.tgz",
-      "integrity": "sha512-MmN20CNF7tex0xWUssifWk/z31ON2DNO90v1MCrC4S1klOv6kzL9BjLIxHflHbuSfZxeRBrXoAlOlfL7BXyFNg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vitepress-md-var/-/vitepress-md-var-0.2.3.tgz",
+      "integrity": "sha512-kOirHuXmTRWiomgH48nKDw9AZ/uOzRu92YDCMnPO9VpBJswGkhpkqeJ6LzUWiVvMoyPmMCvMJSA7mjxt7YBaAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5427,9 +5427,9 @@
       }
     },
     "vitepress-md-var": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/vitepress-md-var/-/vitepress-md-var-0.2.2.tgz",
-      "integrity": "sha512-MmN20CNF7tex0xWUssifWk/z31ON2DNO90v1MCrC4S1klOv6kzL9BjLIxHflHbuSfZxeRBrXoAlOlfL7BXyFNg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vitepress-md-var/-/vitepress-md-var-0.2.3.tgz",
+      "integrity": "sha512-kOirHuXmTRWiomgH48nKDw9AZ/uOzRu92YDCMnPO9VpBJswGkhpkqeJ6LzUWiVvMoyPmMCvMJSA7mjxt7YBaAw==",
       "dev": true
     },
     "vitepress-plugin-tabs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "patch-package": "^8.0.0",
         "postinstall-postinstall": "^2.1.0",
-        "vitepress-md-var": "^0.2.0",
+        "vitepress-md-var": "^0.2.2",
         "vitepress-plugin-tabs": "^0.5.0"
       }
     },
@@ -3182,9 +3182,9 @@
       }
     },
     "node_modules/vitepress-md-var": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/vitepress-md-var/-/vitepress-md-var-0.2.0.tgz",
-      "integrity": "sha512-7io83q0iz/fWQJVCN/2SdGIBuBubkvOzqqelgKdObp+wSxEpBubig3CafxpfWA7aKg60DWlzEuqLfFctw/9oVQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/vitepress-md-var/-/vitepress-md-var-0.2.2.tgz",
+      "integrity": "sha512-MmN20CNF7tex0xWUssifWk/z31ON2DNO90v1MCrC4S1klOv6kzL9BjLIxHflHbuSfZxeRBrXoAlOlfL7BXyFNg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5427,9 +5427,9 @@
       }
     },
     "vitepress-md-var": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/vitepress-md-var/-/vitepress-md-var-0.2.0.tgz",
-      "integrity": "sha512-7io83q0iz/fWQJVCN/2SdGIBuBubkvOzqqelgKdObp+wSxEpBubig3CafxpfWA7aKg60DWlzEuqLfFctw/9oVQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/vitepress-md-var/-/vitepress-md-var-0.2.2.tgz",
+      "integrity": "sha512-MmN20CNF7tex0xWUssifWk/z31ON2DNO90v1MCrC4S1klOv6kzL9BjLIxHflHbuSfZxeRBrXoAlOlfL7BXyFNg==",
       "dev": true
     },
     "vitepress-plugin-tabs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0",
-    "vitepress-md-var": "^0.2.2",
+    "vitepress-md-var": "^0.2.3",
     "vitepress-plugin-tabs": "^0.5.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0",
-    "vitepress-md-var": "^0.2.0",
+    "vitepress-md-var": "^0.2.2",
     "vitepress-plugin-tabs": "^0.5.0"
   },
   "dependencies": {


### PR DESCRIPTION
### **User description**
- Prevents self-xss by HTML encoding variable values
- Fixes issue where variables were not detected on page reload
- Adds variable reset button

___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Updated `vitepress-md-var` dependency to version 0.2.3.

- Fixed self-XSS by HTML encoding variable values.

- Resolved issue with variable detection on page reload.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Updated `vitepress-md-var` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Updated `vitepress-md-var` dependency from version 0.2.0 to 0.2.3.


</details>


  </td>
  <td><a href="https://github.com/The-Hacker-Recipes/The-Hacker-Recipes/pull/160/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>