### PR TITLE
Add 0xblank handle updated on pages

### DIFF
--- a/docs/src/ad/movement/dacl/addmember.md
+++ b/docs/src/ad/movement/dacl/addmember.md
@@ -1,5 +1,5 @@
 ---
-authors: CravateRouge, ShutdownRepo, sckdev
+authors: CravateRouge, ShutdownRepo, sckdev, 0xblank
 category: ad
 ---
 

--- a/docs/src/ad/movement/dacl/readgmsapassword.md
+++ b/docs/src/ad/movement/dacl/readgmsapassword.md
@@ -1,5 +1,5 @@
 ---
-authors: CravateRouge, PfiatDe, ShutdownRepo
+authors: CravateRouge, PfiatDe, ShutdownRepo, 0xblank
 category: ad
 ---
 

--- a/docs/src/ad/movement/dacl/targeted-kerberoasting.md
+++ b/docs/src/ad/movement/dacl/targeted-kerberoasting.md
@@ -1,5 +1,5 @@
 ---
-authors: ShutdownRepo, sckdev
+authors: ShutdownRepo, sckdev, 0xblank
 category: ad
 ---
 


### PR DESCRIPTION
### **User description**
Add 0xblank handle on updated pages for PR #170 #171 #172


___

### **PR Type**
Documentation


___

### **Description**
- Added `0xblank` as an author to the targeted Kerberoasting documentation page.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>targeted-kerberoasting.md</strong><dd><code>Add 0xblank to authors in documentation front matter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/ad/movement/dacl/targeted-kerberoasting.md

- Added `0xblank` to the list of authors in the front matter.


</details>


  </td>
  <td><a href="https://github.com/The-Hacker-Recipes/The-Hacker-Recipes/pull/180/files#diff-a268925a5fa679f5f8afa87cbfe055a08d831235e8cfbf4b1f8a3fece682bf4c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>